### PR TITLE
Update README to exclude a function as second parameter while registering the plugin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,9 +10,7 @@ URL information from the request.
 ```js
 const fastify = require('fastify')()
 
-fastify.register(require('fastify-url-data'), (err) => {
-  if (err) throw err
-})
+fastify.register(require('fastify-url-data'))
 
 fastify.get('/foo', (req, reply) => {
   const urlData = req.urlData()


### PR DESCRIPTION
fixes [#157](https://github.com/fastify/help/issues/157)