### PR TITLE
Remove Node.js core deprecation warning from tests

### DIFF
--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -8,7 +8,7 @@ const Fastify = require('fastify')
 const plugin = require('../')
 const semver = require('semver')
 
-const urlHost = '127.0.0.1'
+const urlHost = 'localhost'
 const urlPath = '/one'
 const urlQuery = 'a=b&c=d'
 


### PR DESCRIPTION
Use hostname instead of IP address in tests to avoid Node.js core
deprecation [DEP0123].

https://github.com/fastify/fastify-url-data/issues/36

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
