### PR TITLE
Added hasRequestDecorator check before calling decorateRequest

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -4,14 +4,16 @@ const fp = require('fastify-plugin')
 const urijs = require('uri-js')
 
 function plugin (fastify, options, next) {
-  fastify.decorateRequest('urlData', function (key) {
-    const scheme = (this.headers[':scheme'] ? this.headers[':scheme'] + ':' : '') + '//'
-    const host = this.headers[':authority'] || this.headers.host
-    const path = this.headers[':path'] || this.raw.url
-    const urlData = urijs.parse(scheme + host + path)
-    if (key) return urlData[key]
-    return urlData
-  })
+  if (!fastify.hasRequestDecorator('urlData')) {
+    fastify.decorateRequest('urlData', function (key) {
+      const scheme = (this.headers[':scheme'] ? this.headers[':scheme'] + ':' : '') + '//'
+      const host = this.headers[':authority'] || this.headers.host
+      const path = this.headers[':path'] || this.raw.url
+      const urlData = urijs.parse(scheme + host + path)
+      if (key) return urlData[key]
+      return urlData
+    })
+  }
   next()
 }
 

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -98,3 +98,16 @@ test('parses a full URI in HTTP2', { skip: semver.lt(process.versions.node, '8.8
 
   t.tearDown(() => fastify.close())
 })
+
+test('can register plugin multiple times without throwing an error', (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  t.doesNotThrow(() => {
+    fastify
+      .register(plugin)
+      .register(plugin)
+  }, 'Does not throw "FastifyError: The decorator \'urlData\' has already been added!"')
+
+  t.tearDown(() => fastify.close())
+})


### PR DESCRIPTION
fixes #88
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~ _- no `npm run benchmark` in this repo_
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added _- I don't think that a change in the documentation is needed_
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
