### PR TITLE
Use fast-uri instead of uri-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "tsd": "~0.25.0"
   },
   "dependencies": {
-    "fastify-plugin": "^4.0.0",
-    "uri-js": "^4.2.1"
+    "fast-uri": "^2.2.0",
+    "fastify-plugin": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugin.js
+++ b/plugin.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const urijs = require('uri-js')
+const fastUri = require('fast-uri')
 
 function fastifyUrlData (fastify, options, next) {
   fastify.decorateRequest('urlData', function (key) {
     const scheme = this.headers[':scheme'] ? this.headers[':scheme'] : this.protocol
     const host = this.headers[':authority'] || this.headers.host
     const path = this.headers[':path'] || this.raw.url
-    const urlData = urijs.parse(scheme + '://' + host + path)
+    const urlData = fastUri.parse(scheme + '://' + host + path)
     if (key) return urlData[key]
     return urlData
   })

--- a/types/fastify-url-data.d.ts
+++ b/types/fastify-url-data.d.ts
@@ -1,12 +1,12 @@
 import { FastifyPluginCallback } from 'fastify';
-import { URIComponents } from 'uri-js'
+import { URIComponent } from 'fast-uri'
 
 type FastifyUrlData = FastifyPluginCallback
 
 declare module 'fastify' {
   interface FastifyRequest {
-    urlData<K extends keyof URIComponents>(target: K): URIComponents[K]
-    urlData(): URIComponents
+    urlData<K extends keyof URIComponent>(target: K): URIComponent[K]
+    urlData(): URIComponent
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #122 

This PR switches `@fastify/url-data` to use https://github.com/fastify/fast-uri instead of https://github.com/garycourt/uri-js

I wrote a little benchmark using `app.inject` and here are the results.

```sh
➜  fastify-url-data git:(master) ✗ node benchmark.js
uri-js: @fastify/url-data x 597,627 ops/sec ±33.47% (28 runs sampled)
fast-uri: @fastify/url-data x 707,374 ops/sec ±26.93% (36 runs sampled)
new URL: @fastify/url-data x 664,445 ops/sec ±29.24% (33 runs sampled)
```

Thanks!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
