### PR TITLE
fix: Use X-Forwarded-Host when trustProxy is set on fastify instance

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -6,7 +6,7 @@ const urijs = require('uri-js')
 function fastifyUrlData (fastify, options, next) {
   fastify.decorateRequest('urlData', function (key) {
     const scheme = this.headers[':scheme'] ? this.headers[':scheme'] : this.protocol
-    const host = this.headers[':authority'] || this.headers.host
+    const host = this.hostname
     const path = this.headers[':path'] || this.raw.url
     const urlData = urijs.parse(scheme + '://' + host + path)
     if (key) return urlData[key]

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -9,6 +9,7 @@ const plugin = require('../')
 const semver = require('semver')
 
 const urlHost = 'localhost'
+const urlForwardedHost = 'example.com'
 const urlPath = '/one'
 const urlQuery = 'a=b&c=d'
 const httpScheme = 'http'
@@ -100,6 +101,84 @@ test('parses a full URI in HTTP2', { skip: semver.lt(process.versions.node, '8.8
 
     port = fastify.server.address().port
     h2url.concat({ url: `https://${urlHost}:${port}${urlPath}?${urlQuery}#foo` }).then(() => {})
+  })
+
+  t.teardown(() => fastify.close())
+})
+
+test('parses a full URI using X-Forwarded-Host when trustProxy is set', (t) => {
+  t.plan(10)
+  let port
+  const fastify = Fastify({ trustProxy: true }) // Setting trustProxy true will use X-Forwarded-Host header if set
+
+  fastify
+    .register(plugin)
+    .after((err) => {
+      if (err) t.error(err)
+    })
+
+  fastify.get(urlPath, (req, reply) => {
+    const uriData = req.urlData()
+    t.equal(uriData.host, urlForwardedHost)
+    t.equal(uriData.port, port)
+    t.equal(uriData.path, urlPath)
+    t.equal(uriData.query, urlQuery)
+    t.equal(uriData.scheme, httpScheme)
+    t.equal(req.urlData('host'), urlForwardedHost)
+    t.equal(req.urlData('port'), port)
+    t.equal(req.urlData('path'), urlPath)
+    t.equal(req.urlData('query'), urlQuery)
+    t.equal(req.urlData('scheme'), httpScheme)
+    reply.send()
+  })
+
+  fastify.listen({ port: 0 }, (err) => {
+    fastify.server.unref()
+    if (err) t.threw(err)
+
+    port = fastify.server.address().port
+    http
+      .get(`http://${urlHost}:${port}${urlPath}?${urlQuery}#foo`, { headers: { 'X-Forwarded-Host': `${urlForwardedHost}:${port}` } }, () => {})
+      .on('error', t.threw)
+  })
+
+  t.teardown(() => fastify.close())
+})
+
+test('parses a full URI ignoring X-Forwarded-Host when trustProxy is not set', (t) => {
+  t.plan(10)
+  let port
+  const fastify = Fastify()
+
+  fastify
+    .register(plugin)
+    .after((err) => {
+      if (err) t.error(err)
+    })
+
+  fastify.get(urlPath, (req, reply) => {
+    const uriData = req.urlData()
+    t.equal(uriData.host, urlHost)
+    t.equal(uriData.port, port)
+    t.equal(uriData.path, urlPath)
+    t.equal(uriData.query, urlQuery)
+    t.equal(uriData.scheme, httpScheme)
+    t.equal(req.urlData('host'), urlHost)
+    t.equal(req.urlData('port'), port)
+    t.equal(req.urlData('path'), urlPath)
+    t.equal(req.urlData('query'), urlQuery)
+    t.equal(req.urlData('scheme'), httpScheme)
+    reply.send()
+  })
+
+  fastify.listen({ port: 0 }, (err) => {
+    fastify.server.unref()
+    if (err) t.threw(err)
+
+    port = fastify.server.address().port
+    http
+      .get(`http://${urlHost}:${port}${urlPath}?${urlQuery}#foo`, { headers: { 'X-Forwarded-Host': `${urlForwardedHost}:${port}` } }, () => {})
+      .on('error', t.threw)
   })
 
   t.teardown(() => fastify.close())


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #124 

This PR gets the host from the fastify request directly in order to be more consistent with the way fastify handles `X-Forwarded-Host` header when `trustProxy` is set on the fastify instance. 

This should fix the issue where host would not be set correctly for forwarded requests, even when `trustProxy` was set.

See how fastify determines the hostname: https://github.com/fastify/fastify/blob/f1bd80e007b019a2708c5fc1ff8340b0082908e7/lib/request.js#L118

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
