### PR TITLE
Fix: make port optional when parsing URL

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -9,7 +9,7 @@ function fastifyUrlData (fastify, options, next) {
     const host = this.hostname
     const port = this.port
     const path = this.headers[':path'] || this.raw.url
-    const urlData = parse(`${scheme}://${host}:${port}${path}`)
+    const urlData = parse(`${scheme}://${host}${port ? ':' + port : ''}${path}`)
     if (key) return urlData[key]
     return urlData
   })

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -183,3 +183,19 @@ test('parses a full URI ignoring X-Forwarded-Host when trustProxy is not set', (
 
   t.teardown(() => fastify.close())
 })
+
+test('should parse path without a port specified', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify
+    .register(plugin)
+
+  fastify.get('/', (req, reply) => {
+    const path = req.urlData('path')
+    reply.send('That worked, path is ' + path)
+  })
+
+  const res = await fastify.inject({ url: '/', headers: { host: 'localhost' } })
+  t.equal(res.statusCode, 200)
+  t.equal(res.body, 'That worked, path is /')
+})


### PR DESCRIPTION
URL parsing is broken when port is not specified, as the URL is basically invalid in this case.

Fixes #153

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)