### PR TITLE
chore: migrate to node test runner

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "node --test",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "precommit": [
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.3",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "h2url": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "node --test",
     "test:typescript": "tsd"
   },
   "precommit": [
@@ -65,8 +65,6 @@
     "fastify": "^5.0.0",
     "h2url": "^0.2.0",
     "neostandard": "^0.12.0",
-    "semver": "^7.5.4",
-    "tap": "^18.6.1",
     "tsd": "~0.31.0"
   },
   "dependencies": {

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -20,7 +20,7 @@ test('parses a full URI', async (t) => {
   fastify
     .register(plugin)
     .after((err) => {
-      t.assert.ok(!err)
+      t.assert.ifError(err)
     })
 
   fastify.get(urlPath, (req, reply) => {
@@ -63,7 +63,7 @@ test('parses a full URI in HTTP2', async (t) => {
   fastify
     .register(plugin)
     .after((err) => {
-      t.assert.ok(!err)
+      t.assert.ifError(err)
     })
 
   fastify.get(urlPath, (req, reply) => {
@@ -97,7 +97,7 @@ test('parses a full URI using X-Forwarded-Host when trustProxy is set', async (t
   fastify
     .register(plugin)
     .after((err) => {
-      t.assert.ok(!err)
+      t.assert.ifError(err)
     })
 
   fastify.get(urlPath, (req, reply) => {
@@ -131,7 +131,7 @@ test('parses a full URI ignoring X-Forwarded-Host when trustProxy is not set', a
   fastify
     .register(plugin)
     .after((err) => {
-      t.assert.ok(!err)
+      t.assert.ifError(err)
     })
 
   fastify.get(urlPath, (req, reply) => {

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -2,11 +2,9 @@
 
 const fs = require('node:fs')
 const join = require('node:path').join
-const http = require('node:http')
-const test = require('tap').test
+const { test } = require('node:test')
 const Fastify = require('fastify')
-const plugin = require('../')
-const semver = require('semver')
+const plugin = require('..')
 
 const urlHost = 'localhost'
 const urlForwardedHost = 'example.com'
@@ -15,173 +13,149 @@ const urlQuery = 'a=b&c=d'
 const httpScheme = 'http'
 const httpsScheme = 'https'
 
-test('parses a full URI', (t) => {
-  t.plan(10)
-  let port
+test('parses a full URI', async (t) => {
+  t.plan(11)
   const fastify = Fastify()
 
   fastify
     .register(plugin)
     .after((err) => {
-      if (err) t.error(err)
+      t.assert.ok(!err)
     })
 
   fastify.get(urlPath, (req, reply) => {
     const uriData = req.urlData()
-    t.equal(uriData.host, urlHost)
-    t.equal(uriData.port, port)
-    t.equal(uriData.path, urlPath)
-    t.equal(uriData.query, urlQuery)
-    t.equal(uriData.scheme, httpScheme)
-    t.equal(req.urlData('host'), urlHost)
-    t.equal(req.urlData('port'), port)
-    t.equal(req.urlData('path'), urlPath)
-    t.equal(req.urlData('query'), urlQuery)
-    t.equal(req.urlData('scheme'), httpScheme)
+    t.assert.deepStrictEqual(uriData.host, urlHost)
+    t.assert.deepStrictEqual(uriData.port, port)
+    t.assert.deepStrictEqual(uriData.path, urlPath)
+    t.assert.deepStrictEqual(uriData.query, urlQuery)
+    t.assert.deepStrictEqual(uriData.scheme, httpScheme)
+    t.assert.deepStrictEqual(req.urlData('host'), urlHost)
+    t.assert.deepStrictEqual(req.urlData('port'), port)
+    t.assert.deepStrictEqual(req.urlData('path'), urlPath)
+    t.assert.deepStrictEqual(req.urlData('query'), urlQuery)
+    t.assert.deepStrictEqual(req.urlData('scheme'), httpScheme)
     reply.send()
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
-    if (err) t.threw(err)
+  await fastify.listen({ port: 0 })
+  const port = fastify.server.address().port
+  fastify.server.unref()
 
-    port = fastify.server.address().port
-    http
-      .get(`http://${urlHost}:${port}${urlPath}?${urlQuery}#foo`, () => {})
-      .on('error', t.threw)
-  })
+  await fetch(`http://${urlHost}:${port}${urlPath}?${urlQuery}#foo`)
 
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 })
 
-test('parses a full URI in HTTP2', { skip: semver.lt(process.versions.node, '8.8.0') }, (t) => {
+test('parses a full URI in HTTP2', async (t) => {
   t.plan(11)
 
   const h2url = require('h2url')
 
-  let port
-  let fastify
-  try {
-    fastify = Fastify({
-      http2: true,
-      https: {
-        key: fs.readFileSync(join(__dirname, 'https', 'fastify.key')),
-        cert: fs.readFileSync(join(__dirname, 'https', 'fastify.cert'))
-      }
-    })
-    t.pass('Key/cert successfully loaded')
-  } catch (e) {
-    t.fail('Key/cert loading failed', e)
-  }
+  const fastify = Fastify({
+    http2: true,
+    https: {
+      key: fs.readFileSync(join(__dirname, 'https', 'fastify.key')),
+      cert: fs.readFileSync(join(__dirname, 'https', 'fastify.cert'))
+    }
+  })
 
   fastify
     .register(plugin)
     .after((err) => {
-      if (err) t.error(err)
+      t.assert.ok(!err)
     })
 
   fastify.get(urlPath, (req, reply) => {
     const uriData = req.urlData()
-    t.equal(uriData.host, urlHost)
-    t.equal(uriData.port, port)
-    t.equal(uriData.path, urlPath)
-    t.equal(uriData.query, urlQuery)
-    t.equal(uriData.scheme, httpsScheme)
-    t.equal(req.urlData('host'), urlHost)
-    t.equal(req.urlData('port'), port)
-    t.equal(req.urlData('path'), urlPath)
-    t.equal(req.urlData('query'), urlQuery)
-    t.equal(req.urlData('scheme'), httpsScheme)
+    t.assert.deepStrictEqual(uriData.host, urlHost)
+    t.assert.deepStrictEqual(uriData.port, port)
+    t.assert.deepStrictEqual(uriData.path, urlPath)
+    t.assert.deepStrictEqual(uriData.query, urlQuery)
+    t.assert.deepStrictEqual(uriData.scheme, httpsScheme)
+    t.assert.deepStrictEqual(req.urlData('host'), urlHost)
+    t.assert.deepStrictEqual(req.urlData('port'), port)
+    t.assert.deepStrictEqual(req.urlData('path'), urlPath)
+    t.assert.deepStrictEqual(req.urlData('query'), urlQuery)
+    t.assert.deepStrictEqual(req.urlData('scheme'), httpsScheme)
     reply.send()
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
-    if (err) t.threw(err)
+  await fastify.listen({ port: 0 })
+  const port = fastify.server.address().port
+  fastify.server.unref()
 
-    port = fastify.server.address().port
-    h2url.concat({ url: `https://${urlHost}:${port}${urlPath}?${urlQuery}#foo` }).then(() => {})
-  })
+  await h2url.concat({ url: `https://${urlHost}:${port}${urlPath}?${urlQuery}#foo` })
 
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 })
 
-test('parses a full URI using X-Forwarded-Host when trustProxy is set', (t) => {
-  t.plan(10)
-  let port
+test('parses a full URI using X-Forwarded-Host when trustProxy is set', async (t) => {
+  t.plan(11)
   const fastify = Fastify({ trustProxy: true }) // Setting trustProxy true will use X-Forwarded-Host header if set
 
   fastify
     .register(plugin)
     .after((err) => {
-      if (err) t.error(err)
+      t.assert.ok(!err)
     })
 
   fastify.get(urlPath, (req, reply) => {
     const uriData = req.urlData()
-    t.equal(uriData.host, urlForwardedHost)
-    t.equal(uriData.port, port)
-    t.equal(uriData.path, urlPath)
-    t.equal(uriData.query, urlQuery)
-    t.equal(uriData.scheme, httpScheme)
-    t.equal(req.urlData('host'), urlForwardedHost)
-    t.equal(req.urlData('port'), port)
-    t.equal(req.urlData('path'), urlPath)
-    t.equal(req.urlData('query'), urlQuery)
-    t.equal(req.urlData('scheme'), httpScheme)
+    t.assert.deepStrictEqual(uriData.host, urlForwardedHost)
+    t.assert.deepStrictEqual(uriData.port, port)
+    t.assert.deepStrictEqual(uriData.path, urlPath)
+    t.assert.deepStrictEqual(uriData.query, urlQuery)
+    t.assert.deepStrictEqual(uriData.scheme, httpScheme)
+    t.assert.deepStrictEqual(req.urlData('host'), urlForwardedHost)
+    t.assert.deepStrictEqual(req.urlData('port'), port)
+    t.assert.deepStrictEqual(req.urlData('path'), urlPath)
+    t.assert.deepStrictEqual(req.urlData('query'), urlQuery)
+    t.assert.deepStrictEqual(req.urlData('scheme'), httpScheme)
     reply.send()
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
-    if (err) t.threw(err)
+  await fastify.listen({ port: 0 })
+  const port = fastify.server.address().port
+  fastify.server.unref()
 
-    port = fastify.server.address().port
-    http
-      .get(`http://${urlHost}:${port}${urlPath}?${urlQuery}#foo`, { headers: { 'X-Forwarded-Host': `${urlForwardedHost}:${port}` } }, () => {})
-      .on('error', t.threw)
-  })
+  await fetch(`http://${urlHost}:${fastify.server.address().port}${urlPath}?${urlQuery}#foo`, { headers: { 'X-Forwarded-Host': `${urlForwardedHost}:${port}` } })
 
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 })
 
-test('parses a full URI ignoring X-Forwarded-Host when trustProxy is not set', (t) => {
-  t.plan(10)
-  let port
+test('parses a full URI ignoring X-Forwarded-Host when trustProxy is not set', async (t) => {
+  t.plan(11)
   const fastify = Fastify()
 
   fastify
     .register(plugin)
     .after((err) => {
-      if (err) t.error(err)
+      t.assert.ok(!err)
     })
 
   fastify.get(urlPath, (req, reply) => {
     const uriData = req.urlData()
-    t.equal(uriData.host, urlHost)
-    t.equal(uriData.port, port)
-    t.equal(uriData.path, urlPath)
-    t.equal(uriData.query, urlQuery)
-    t.equal(uriData.scheme, httpScheme)
-    t.equal(req.urlData('host'), urlHost)
-    t.equal(req.urlData('port'), port)
-    t.equal(req.urlData('path'), urlPath)
-    t.equal(req.urlData('query'), urlQuery)
-    t.equal(req.urlData('scheme'), httpScheme)
+    t.assert.deepStrictEqual(uriData.host, urlHost)
+    t.assert.deepStrictEqual(uriData.port, port)
+    t.assert.deepStrictEqual(uriData.path, urlPath)
+    t.assert.deepStrictEqual(uriData.query, urlQuery)
+    t.assert.deepStrictEqual(uriData.scheme, httpScheme)
+    t.assert.deepStrictEqual(req.urlData('host'), urlHost)
+    t.assert.deepStrictEqual(req.urlData('port'), port)
+    t.assert.deepStrictEqual(req.urlData('path'), urlPath)
+    t.assert.deepStrictEqual(req.urlData('query'), urlQuery)
+    t.assert.deepStrictEqual(req.urlData('scheme'), httpScheme)
     reply.send()
   })
 
-  fastify.listen({ port: 0 }, (err) => {
-    fastify.server.unref()
-    if (err) t.threw(err)
+  await fastify.listen({ port: 0 })
+  const port = fastify.server.address().port
+  fastify.server.unref()
 
-    port = fastify.server.address().port
-    http
-      .get(`http://${urlHost}:${port}${urlPath}?${urlQuery}#foo`, { headers: { 'X-Forwarded-Host': `${urlForwardedHost}:${port}` } }, () => {})
-      .on('error', t.threw)
-  })
+  await fetch(`http://${urlHost}:${fastify.server.address().port}${urlPath}?${urlQuery}#foo`, { headers: { 'X-Forwarded-Host': `${urlForwardedHost}:${port}` } })
 
-  t.teardown(() => fastify.close())
+  t.after(() => fastify.close())
 })
 
 test('should parse path without a port specified', async (t) => {
@@ -196,6 +170,6 @@ test('should parse path without a port specified', async (t) => {
   })
 
   const res = await fastify.inject({ url: '/', headers: { host: 'localhost' } })
-  t.equal(res.statusCode, 200)
-  t.equal(res.body, 'That worked, path is /')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.body, 'That worked, path is /')
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

- migrated to node test runner
- removed semver dep, as not used anymore (the plugin always target node >= v20)
- use fetch instead of http