### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/fastify/fastify-url-data.git"
+    "url": "git+https://github.com/fastify/fastify-url-data.git"
   },
   "keywords": [
     "fastify"


### PR DESCRIPTION
## Summary

- Update the package `repository.url` from the SSH GitHub form to a public HTTPS URL.
- Leave runtime code, dependencies, package version, homepage, bugs metadata, funding metadata, and package entrypoints unchanged.

## Why

This repository is public, so npm consumers should be able to follow the source repository link without SSH or GitHub key setup.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository?.url !== 'git+https://github.com/fastify/fastify-url-data.git') throw new Error(JSON.stringify(p.repository))"`
- `git diff --check`
- `pnpm install --ignore-scripts --lockfile=false`
- `pnpm exec eslint`
- `pnpm exec c8 --100 node --test`
- `pnpm exec tstyche`

I used pnpm for local dependency installation because the local Codex runtime does not include an `npm` binary. No runtime code was changed.
